### PR TITLE
Update vector-icons version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "prop-types": "^15.6.0"
   },
   "dependencies": {
-    "react-native-vector-icons": "^2.1.0"
+    "react-native-vector-icons": "^4.4.0"
   }
 }


### PR DESCRIPTION
vector-icons version 2.x can not work with react-native ^0.49.x